### PR TITLE
Full url to og:image and twitter:image

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,14 +9,14 @@
   <meta name="author" content="Mohammadreza Hajianpour">
   <meta property="og:title" content="Meshki UI"/>
   <meta property="og:type" content="website"/>
-  <meta property="og:image" content="meta-image.png"/>
+  <meta property="og:image" content="https://borderliner.github.io/Meshki/meta-image.png"/>
   <meta property="og:url" content="https://borderliner.github.io/Meshki/"/>
   <meta property="og:description" content="Meshki: The most stylish CSS library on planet Earth!"/>
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@Meshki_UI">
   <meta name="twitter:title" content="Meshki UI">
   <meta name="twitter:description" content="Meshki: The most stylish CSS library on planet Earth!">
-  <meta name="twitter:image" content="meta-image.png">
+  <meta name="twitter:image" content="https://borderliner.github.io/Meshki/meta-image.png">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
   <!-- DEVELOPMENT FILES


### PR DESCRIPTION
As you can see on https://cards-dev.twitter.com/validator image is not showing currently for https://borderliner.github.io/Meshki/. This change fixed it for me.