### PR TITLE
Change openNav() to openSidenav() in index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -381,7 +381,7 @@
 &lt;nav class="fixed">
   &lt;ul>
     &lt;!-- Note that javascript:void(0) stops your page from jumping to the top -->
-    &lt;li>&lt;a class="logo" href="javascript:void(0)" onclick="meshki.openNav()">Meshki&lt;/a>&lt;/li>
+    &lt;li>&lt;a class="logo" href="javascript:void(0)" onclick="meshki.openSidenav()">Meshki&lt;/a>&lt;/li>
     &lt;li>&lt;a href="https://github.com/Borderliner/Meshki/releases">News&lt;/a>&lt;/li>
     &lt;li>&lt;a href="https://github.com/Borderliner/Meshki">GitHub&lt;/a>&lt;/li>
 


### PR DESCRIPTION
Hey, this pull request fixes a part of code that was not changed after the 'API change' mentioned in Borderliner/Meshki#13. The example code in the "Navbar" section uses meshki.openNav() instead of meshki.openSidenav(), and Firefox will emit an error ('TypeError: meshki.openNav is not a function') if the code on the site is used.